### PR TITLE
feat(useDialogs): pass classNames to dialog

### DIFF
--- a/docs/hooks/useDialogs.md
+++ b/docs/hooks/useDialogs.md
@@ -29,6 +29,15 @@ interface IDialogsContext {
 			showNoButton: boolean;
 			/** Whether the "no" button should be visible */
 			showYesButton: boolean;
+			/** Specify CSS class names for each component of the dialog. This is meant to be used with `makeStyles/useStyles`. */
+			classNames?: Partial<{
+				dialog: string;
+				dialogTitle: string;
+				dialogContent: string;
+				dialogActions: string;
+				yesButton: string;
+				noButton: string;
+			}>;
 		}>,
 	) => Promise<boolean>;
 	/** Hide a currently open modal dialog */

--- a/src/lib/app/IoBrokerApp.tsx
+++ b/src/lib/app/IoBrokerApp.tsx
@@ -182,6 +182,7 @@ export const IoBrokerApp: React.FC<IoBrokerAppProps> = (props) => {
 				yesButtonText: options?.yesButtonText ?? "Ja",
 				showNoButton: options?.showNoButton ?? true,
 				noButtonText: options?.noButtonText ?? "Nein",
+				classNames: options?.classNames,
 
 				yesButtonClick: () => {
 					hideModal();

--- a/src/lib/components/ModalDialog.tsx
+++ b/src/lib/components/ModalDialog.tsx
@@ -26,6 +26,15 @@ export interface ModalDialogProps {
 	 * If this callback returns `false`, the dialog will not close.
 	 */
 	onClose: () => boolean | void;
+
+	classNames?: Partial<{
+		dialog: string;
+		dialogTitle: string;
+		dialogContent: string;
+		dialogActions: string;
+		yesButton: string;
+		noButton: string;
+	}>;
 }
 
 export type ModalState = {
@@ -42,6 +51,7 @@ export type ShowModal = (
 		noButtonEnabled: boolean;
 		showNoButton: boolean;
 		showYesButton: boolean;
+		classNames?: ModalDialogProps["classNames"];
 	}>,
 ) => Promise<boolean>;
 
@@ -65,9 +75,15 @@ export const ModalDialog: React.FC<ModalDialogProps> = (props) => {
 			aria-labelledby="alert-dialog-title"
 			aria-describedby="alert-dialog-description"
 			maxWidth={false}
+			className={props.classNames?.dialog}
 		>
-			<DialogTitle id="alert-dialog-title">{props.title}</DialogTitle>
-			<DialogContent>
+			<DialogTitle
+				id="alert-dialog-title"
+				className={props.classNames?.dialogTitle}
+			>
+				{props.title}
+			</DialogTitle>
+			<DialogContent className={props.classNames?.dialogContent}>
 				{typeof props.message === "string" ? (
 					<DialogContentText
 						id="alert-dialog-description"
@@ -80,7 +96,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = (props) => {
 				)}
 			</DialogContent>
 			{(props.showYesButton || props.showNoButton) && (
-				<DialogActions>
+				<DialogActions className={props.classNames?.dialogActions}>
 					{props.showYesButton && (
 						<Button
 							onClick={() => {
@@ -89,6 +105,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = (props) => {
 							color="primary"
 							autoFocus
 							disabled={props.yesButtonEnabled === false}
+							className={props.classNames?.yesButton}
 						>
 							{props.yesButtonText}
 						</Button>
@@ -100,6 +117,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = (props) => {
 							}}
 							color="primary"
 							disabled={props.noButtonEnabled === false}
+							className={props.classNames?.noButton}
 						>
 							{props.noButtonText}
 						</Button>


### PR DESCRIPTION
This PR adds the ability to pass CSS class names to each component of the dialog. E.g.
```js
const useStyles = makeStyles(...);

const myComponent = () => {
  const classes = useStyles();
  // ...
  showModal("Title", <Message />, {
    classNames: {
      dialog: classes.myclasses
    }
  });
  // ...
}
```
fixes: #3