### PR TITLE
fix: `Loader` import

### DIFF
--- a/src/lib/app/IoBrokerApp.tsx
+++ b/src/lib/app/IoBrokerApp.tsx
@@ -5,7 +5,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import { extend } from "alcalzone-shared/objects";
 import React from "react";
-import Loader from "../components/Loader";
+import { Loader } from "../components/Loader";
 import type { ModalState, ShowModal } from "../components/ModalDialog";
 import { ModalDialog } from "../components/ModalDialog";
 import type {


### PR DESCRIPTION
Problems during installation
```cmd
npm ERR! src/lib/app/IoBrokerApp.tsx(8,8): error TS2613: Module '"C:/Users/alex/AppData/Local/npm-cache/_cacache/tmp/git-cloneyJxxEd/src/lib/components/Loader"' has no default export. Did you mean to use 'import { Loader } from "C:/Users/alex/AppData/Local/npm-cache/_cacache/tmp/git-cloneyJxxEd/src/lib/components/Loader"' instead?
```